### PR TITLE
ngAfterContentInit

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,9 +1,11 @@
-
 <!-- <app-user-management></app-user-management> -->
 <!-- <app-counter></app-counter> -->
 <!-- <app-task-list></app-task-list> -->
 <!-- <app-source></app-source> -->
 <!-- <app-char-counter></app-char-counter> -->
 <!-- <app-palindrome></app-palindrome> -->
-<app-chunky-monkey></app-chunky-monkey>
+<!-- <app-chunky-monkey></app-chunky-monkey> -->
 
+<app-card>
+  <app-projected-content></app-projected-content>
+</app-card>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,8 @@ import { SourceComponent } from './parent-child/source/source.component';
 import { CharCounterComponent } from './char counter/char-counter/char-counter.component';
 import { PalindromeComponent } from './palindrome/palindrome.component';
 import { ChunkyMonkeyComponent } from './chunky-monkey/chunky-monkey.component';
+import { ProjectedContentComponent } from './ngAfterContentInit/projected-content/projected-content.component';
+import { CardComponent } from './ngAfterContentInit/card/card.component';
 
 
 @NgModule({
@@ -23,7 +25,9 @@ import { ChunkyMonkeyComponent } from './chunky-monkey/chunky-monkey.component';
     SourceComponent,
     CharCounterComponent,
     PalindromeComponent,
-    ChunkyMonkeyComponent
+    ChunkyMonkeyComponent,
+    ProjectedContentComponent,
+    CardComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/ngAfterContentInit/card/card.component.css
+++ b/src/app/ngAfterContentInit/card/card.component.css
@@ -1,0 +1,5 @@
+.card {
+  border: 1px solid #ccc;
+  padding: 16px;
+  margin: 16px;
+}

--- a/src/app/ngAfterContentInit/card/card.component.html
+++ b/src/app/ngAfterContentInit/card/card.component.html
@@ -1,0 +1,3 @@
+<div class="card">
+  <ng-content></ng-content>
+</div>

--- a/src/app/ngAfterContentInit/card/card.component.spec.ts
+++ b/src/app/ngAfterContentInit/card/card.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardComponent } from './card.component';
+
+describe('CardComponent', () => {
+  let component: CardComponent;
+  let fixture: ComponentFixture<CardComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [CardComponent]
+    });
+    fixture = TestBed.createComponent(CardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ngAfterContentInit/card/card.component.ts
+++ b/src/app/ngAfterContentInit/card/card.component.ts
@@ -1,0 +1,18 @@
+import { Component, ContentChild, AfterContentInit } from '@angular/core';
+import { ProjectedContentComponent } from '../projected-content/projected-content.component';
+
+@Component({
+  selector: 'app-card',
+  templateUrl: './card.component.html',
+  styleUrls: ['./card.component.css'],
+})
+export class CardComponent implements AfterContentInit {
+  @ContentChild(ProjectedContentComponent)
+  projectedContent: ProjectedContentComponent;
+
+  ngAfterContentInit(): void {
+    console.log('Content has been projected and initialized!');
+    // You can now access the projected content and perform any logic on it
+    console.log(this.projectedContent);
+  }
+}

--- a/src/app/ngAfterContentInit/projected-content/projected-content.component.html
+++ b/src/app/ngAfterContentInit/projected-content/projected-content.component.html
@@ -1,0 +1,1 @@
+<p>It is the projected content.</p>

--- a/src/app/ngAfterContentInit/projected-content/projected-content.component.spec.ts
+++ b/src/app/ngAfterContentInit/projected-content/projected-content.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectedContentComponent } from './projected-content.component';
+
+describe('ProjectedContentComponent', () => {
+  let component: ProjectedContentComponent;
+  let fixture: ComponentFixture<ProjectedContentComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProjectedContentComponent]
+    });
+    fixture = TestBed.createComponent(ProjectedContentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ngAfterContentInit/projected-content/projected-content.component.ts
+++ b/src/app/ngAfterContentInit/projected-content/projected-content.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-projected-content',
+  templateUrl: './projected-content.component.html',
+  styleUrls: ['./projected-content.component.css']
+})
+export class ProjectedContentComponent {
+
+}


### PR DESCRIPTION
Imagine you have a component in Angular that can project content from other components into itself. This is where ngAfterContentInit comes into play. It’s a lifecycle hook that gets called once Angular has fully projected the external content into the component.
